### PR TITLE
chore: raise macOS deployment target

### DIFF
--- a/flutter_frontend/macos/Podfile
+++ b/flutter_frontend/macos/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :osx, '10.14'
+platform :osx, '10.15'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -43,7 +43,7 @@ post_install do |installer|
     
     # Ensure all pods use the minimum deployment target
     target.build_configurations.each do |config|
-      config.build_settings['MACOSX_DEPLOYMENT_TARGET'] = '10.14'
+      config.build_settings['MACOSX_DEPLOYMENT_TARGET'] = '10.15'
     end
   end
 end


### PR DESCRIPTION
## Summary
- bump macOS platform version to 10.15 in Podfile
- ensure all pods use MACOSX_DEPLOYMENT_TARGET 10.15

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68952f229768832cb94e9f75aafe613c